### PR TITLE
Silence spammy logs from camera blobs (AEC_PORT and mm-camera)

### DIFF
--- a/liblog/logprint.c
+++ b/liblog/logprint.c
@@ -201,7 +201,10 @@ static android_LogPriority filterPriForTag(AndroidLogFormat* p_format,
 LIBLOG_ABI_PUBLIC int android_log_shouldPrintLine(AndroidLogFormat* p_format,
                                                   const char* tag,
                                                   android_LogPriority pri) {
-  return pri >= filterPriForTag(p_format, tag);
+    if (!strncmp(tag, "AEC_PORT", 8) || !strncmp(tag, "mm-camera", 9))
+        return 0;
+    else
+        return pri >= filterPriForTag(p_format, tag);
 }
 
 LIBLOG_ABI_PUBLIC AndroidLogFormat* android_log_format_new() {


### PR DESCRIPTION
Log messages under these tags are spammed very hard, destroying logs, and
the messages that are spammed are not useful for debugging.

Change-Id: I9936ef35c2b231230694d70c88dc56c03410f27a